### PR TITLE
New EES version and black formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ or via `git clone`
 git clone https://github.com/UKPLab/gpl.git && cd gpl
 pip install -e .
 ```
+> Meanwhile, please make sure the [correct version of PyTorch](https://pytorch.org/get-started/locally/) has been installed according to your CUDA version.
 
 ## Usage
 GPL accepts data in the [BeIR](https://github.com/UKPLab/beir)-format. For example, we can download the [FiQA](https://sites.google.com/view/fiqa/) dataset hosted by BeIR:

--- a/gpl/toolkit/beir.py
+++ b/gpl/toolkit/beir.py
@@ -2,6 +2,7 @@ import json
 import os
 from typing import Dict
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,26 +15,27 @@ def extract_queries_split(queries: Dict[str, str], qrels: Dict[str, Dict[str, fl
 
 def save_queries(queries: Dict[str, str], output_dir):
     os.makedirs(output_dir, exist_ok=True)
-    save_path = os.path.join(output_dir, 'queries.jsonl')
-    with open(save_path, 'w') as f:
+    save_path = os.path.join(output_dir, "queries.jsonl")
+    with open(save_path, "w") as f:
         for qid, query in queries.items():
             line_dict = {"_id": qid, "text": query, "metadata": {}}
-            line = json.dumps(line_dict) + '\n'
+            line = json.dumps(line_dict) + "\n"
             f.write(line)
-    
-    logger.info(f'Saved (copied) queries into {save_path}')
+
+    logger.info(f"Saved (copied) queries into {save_path}")
+
 
 def save_qrels(qrels: Dict[str, Dict[str, float]], output_dir, split):
-    os.makedirs(os.path.join(output_dir, 'qrels'), exist_ok=True)
+    os.makedirs(os.path.join(output_dir, "qrels"), exist_ok=True)
 
-    assert split in ['train', 'test', 'dev']
-    save_path = os.path.join(output_dir, f'qrels/{split}.tsv')    
-    with open(save_path, 'w') as f:
-        header = 'query-id\tcorpus-id\tscore\n'
+    assert split in ["train", "test", "dev"]
+    save_path = os.path.join(output_dir, f"qrels/{split}.tsv")
+    with open(save_path, "w") as f:
+        header = "query-id\tcorpus-id\tscore\n"
         f.write(header)
         for qid, rels in qrels.items():
             for doc_id, score in rels.items():
-                line = f'{qid}\t{doc_id}\t{score}\n'
+                line = f"{qid}\t{doc_id}\t{score}\n"
                 f.write(line)
 
-    logger.info(f'Saved (copied) qrels into {save_path}')
+    logger.info(f"Saved (copied) qrels into {save_path}")

--- a/gpl/toolkit/dataset.py
+++ b/gpl/toolkit/dataset.py
@@ -5,14 +5,15 @@ from sentence_transformers.readers.InputExample import InputExample
 import random
 import linecache
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 def concat_title_and_body(did: str, corpus: Dict[str, Dict[str, str]], sep: str):
     assert type(did) == str
     document = []
-    title = corpus[did]['title'].strip()
-    body = corpus[did]['text'].strip()
+    title = corpus[did]["title"].strip()
+    body = corpus[did]["text"].strip()
     if len(title):
         document.append(title)
     if len(body):
@@ -21,8 +22,7 @@ def concat_title_and_body(did: str, corpus: Dict[str, Dict[str, str]], sep: str)
 
 
 class HardNegativeDataset(Dataset):
-
-    def __init__(self, jsonl_path, queries, corpus, sep=' '):
+    def __init__(self, jsonl_path, queries, corpus, sep=" "):
         self.jsonl_path = jsonl_path
         self.queries = queries
         self.corpus = corpus
@@ -41,40 +41,40 @@ class HardNegativeDataset(Dataset):
             try:
                 query_dict = json.loads(json_line)
             except:
-                print(json_line, '###index###', index)
+                print(json_line, "###index###", index)
                 raise NotImplementedError
             tuple_sampled = self._sample_tuple(query_dict)
             if tuple_sampled is None:
                 self.none_indices.add(index)
-                logger.info(f'Invalid query at line {index-1}')
+                logger.info(f"Invalid query at line {index-1}")
             else:
                 break
         (query_id, pos_id, neg_id), (query_text, pos_text, neg_text) = tuple_sampled
         return InputExample(
             guid=[query_id, pos_id, neg_id],
-            texts=[query_text, pos_text, neg_text], 
-            label=-1
+            texts=[query_text, pos_text, neg_text],
+            label=-1,
         )
 
     def __len__(self):
         return self.nqueries
 
     def _sample_tuple(self, query_dict):
-        #Get the positive passage ids
-        pos_pids = query_dict['pos']
+        # Get the positive passage ids
+        pos_pids = query_dict["pos"]
         # scores = {item['pid']: item['ce-score'] for item in query_dict['pos']}
 
-        #Get the hard negatives
+        # Get the hard negatives
         neg_pids = set()
-        for system_name, system_negs in query_dict['neg'].items():
+        for system_name, system_negs in query_dict["neg"].items():
             for pid in system_negs:
-                
+
                 if pid not in neg_pids:
                     neg_pids.add(pid)
                     # scores[pid] = item['ce-score']
 
         if len(pos_pids) > 0 and len(neg_pids) > 0:
-            query_text = self.queries[query_dict['qid']]
+            query_text = self.queries[query_dict["qid"]]
 
             pos_pid = random.choice(pos_pids)
             pos_text = concat_title_and_body(pos_pid, self.corpus, self.sep)
@@ -82,14 +82,17 @@ class HardNegativeDataset(Dataset):
             neg_pid = random.choice(list(neg_pids))
             neg_text = concat_title_and_body(neg_pid, self.corpus, self.sep)
 
-            return (query_dict['qid'], pos_pid, neg_pid), (query_text, pos_text, neg_text)
+            return (query_dict["qid"], pos_pid, neg_pid), (
+                query_text,
+                pos_text,
+                neg_text,
+            )
         else:
             return None
 
 
 class GenerativePseudoLabelingDataset(Dataset):
-
-    def __init__(self, tsv_path, queries, corpus, sep=' '):
+    def __init__(self, tsv_path, queries, corpus, sep=" "):
         self.tsv_path = tsv_path
         self.queries = queries
         self.corpus = corpus
@@ -99,16 +102,13 @@ class GenerativePseudoLabelingDataset(Dataset):
     def __getitem__(self, item):
         index = item + 1
         tsv_line = linecache.getline(self.tsv_path, index)
-        qid, pos_pid, neg_pid, label = tsv_line.strip().split('\t')
+        qid, pos_pid, neg_pid, label = tsv_line.strip().split("\t")
         query_text = self.queries[qid]
         pos_text = concat_title_and_body(pos_pid, self.corpus, self.sep)
         neg_text = concat_title_and_body(neg_pid, self.corpus, self.sep)
         label = float(label)  # CE margin between (query, pos) and (query, neg)
 
-        return InputExample(
-            texts=[query_text, pos_text, neg_text], 
-            label=label
-        )
+        return InputExample(texts=[query_text, pos_text, neg_text], label=label)
 
     def __len__(self):
         return self.ntuples

--- a/gpl/toolkit/evaluation.py
+++ b/gpl/toolkit/evaluation.py
@@ -7,36 +7,54 @@ from sentence_transformers import SentenceTransformer
 import sentence_transformers
 import os
 import logging
-import numpy as np 
+import numpy as np
 import json
 from typing import List
 import argparse
 from .sbert import load_sbert
+
 logger = logging.getLogger(__name__)
 
 
 def evaluate(
-    data_path: str, 
-    output_dir: str, 
-    model_name_or_path: str, 
-    max_seq_length: int = 350, 
-    score_function: str = 'dot', 
-    pooling: str = None, 
-    sep: str = ' ', 
+    data_path: str,
+    output_dir: str,
+    model_name_or_path: str,
+    max_seq_length: int = 350,
+    score_function: str = "dot",
+    pooling: str = None,
+    sep: str = " ",
     k_values: List[int] = [1, 3, 5, 10, 20, 100],
-    split: str = 'test'
+    split: str = "test",
 ):
     model: SentenceTransformer = load_sbert(model_name_or_path, pooling, max_seq_length)
-    
+
     pooling_module: sentence_transformers.models.Pooling = model._last_module()
     assert type(pooling_module) == sentence_transformers.models.Pooling
     pooling_mode = pooling_module.get_pooling_mode_str()
-    logger.info(f'Running evaluation with setting: max_seq_length = {max_seq_length}, score_function = {score_function}, split = {split} and pooling: {pooling_mode}')
+    logger.info(
+        f"Running evaluation with setting: max_seq_length = {max_seq_length}, score_function = {score_function}, split = {split} and pooling: {pooling_mode}"
+    )
 
     data_paths = []
-    if 'cqadupstack' in data_path:
-        data_paths = [os.path.join(data_path, sub_dataset) for sub_dataset in \
-            ['android', 'english', 'gaming', 'gis', 'mathematica', 'physics', 'programmers', 'stats', 'tex', 'unix', 'webmasters', 'wordpress',]]
+    if "cqadupstack" in data_path:
+        data_paths = [
+            os.path.join(data_path, sub_dataset)
+            for sub_dataset in [
+                "android",
+                "english",
+                "gaming",
+                "gis",
+                "mathematica",
+                "physics",
+                "programmers",
+                "stats",
+                "tex",
+                "unix",
+                "webmasters",
+                "wordpress",
+            ]
+        ]
     else:
         data_paths.append(data_path)
 
@@ -51,15 +69,19 @@ def evaluate(
         sbert = models.SentenceBERT(sep=sep)
         sbert.q_model = model
         sbert.doc_model = model
-        
+
         model_dres = DRES(sbert, batch_size=16)
-        assert score_function in ['dot', 'cos_sim']
-        retriever = EvaluateRetrieval(model_dres, score_function=score_function, k_values=k_values) # or "dot" for dot-product
+        assert score_function in ["dot", "cos_sim"]
+        retriever = EvaluateRetrieval(
+            model_dres, score_function=score_function, k_values=k_values
+        )  # or "dot" for dot-product
         results = retriever.retrieve(corpus, queries)
 
         #### Evaluate your retrieval using NDCG@k, MAP@K ...
-        ndcg, _map, recall, precision = EvaluateRetrieval.evaluate(qrels, results, k_values)
-        mrr = EvaluateRetrieval.evaluate_custom(qrels, results, k_values, metric='mrr')
+        ndcg, _map, recall, precision = EvaluateRetrieval.evaluate(
+            qrels, results, k_values
+        )
+        mrr = EvaluateRetrieval.evaluate_custom(qrels, results, k_values, metric="mrr")
         ndcgs.append(ndcg)
         _maps.append(_map)
         recalls.append(recall)
@@ -73,27 +95,49 @@ def evaluate(
     mrr = {k: np.mean([score[k] for score in mrrs]) for k in mrr}
 
     os.makedirs(output_dir, exist_ok=True)
-    result_path = os.path.join(output_dir, 'results.json')
-    with open(result_path, 'w') as f:
-        json.dump({
-            'ndcg': ndcg,
-            'map': _map,
-            'recall': recall,
-            'precicion': precision,
-            'mrr': mrr
-        }, f, indent=4)
-    logger.info(f'Saved evaluation results to {result_path}')
+    result_path = os.path.join(output_dir, "results.json")
+    with open(result_path, "w") as f:
+        json.dump(
+            {
+                "ndcg": ndcg,
+                "map": _map,
+                "recall": recall,
+                "precicion": precision,
+                "mrr": mrr,
+            },
+            f,
+            indent=4,
+        )
+    logger.info(f"Saved evaluation results to {result_path}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--data_path')
-    parser.add_argument('--output_dir')
-    parser.add_argument('--model_name_or_path')
-    parser.add_argument('--max_seq_length', type=int, default=350)
-    parser.add_argument('--score_function', choices=['dot', 'cos_sim'], default='dot')
-    parser.add_argument('--pooling', choices=['mean', 'cls', 'max'], default=None)
-    parser.add_argument('--sep', type=str, default=' ', help="Separation token between title and body text for each passage. The concatenation way is `sep.join([title, body])`")
-    parser.add_argument('--k_values', nargs='+', type=int, default=[1, 3, 5, 10, 20, 100], help="The K values in the evaluation. This will compute nDCG@K, recall@K, precision@K and MAP@K")    
-    parser.add_argument('--split', type=str, default='test', choices=['train', 'test', 'dev'], help='Which split to evaluate on')    
+    parser.add_argument("--data_path")
+    parser.add_argument("--output_dir")
+    parser.add_argument("--model_name_or_path")
+    parser.add_argument("--max_seq_length", type=int, default=350)
+    parser.add_argument("--score_function", choices=["dot", "cos_sim"], default="dot")
+    parser.add_argument("--pooling", choices=["mean", "cls", "max"], default=None)
+    parser.add_argument(
+        "--sep",
+        type=str,
+        default=" ",
+        help="Separation token between title and body text for each passage. The concatenation way is `sep.join([title, body])`",
+    )
+    parser.add_argument(
+        "--k_values",
+        nargs="+",
+        type=int,
+        default=[1, 3, 5, 10, 20, 100],
+        help="The K values in the evaluation. This will compute nDCG@K, recall@K, precision@K and MAP@K",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        choices=["train", "test", "dev"],
+        help="Which split to evaluate on",
+    )
     args = parser.parse_args()
     evaluate(**vars(args))

--- a/gpl/toolkit/log.py
+++ b/gpl/toolkit/log.py
@@ -1,11 +1,12 @@
 import logging
 from logging import StreamHandler
 
+
 def set_logger_format():
     root_logger = logging.getLogger()
     formatter = logging.Formatter(
-        fmt='[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        fmt="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
     )
     for handler in root_logger.handlers:
         if isinstance(handler, StreamHandler):

--- a/gpl/toolkit/loss.py
+++ b/gpl/toolkit/loss.py
@@ -2,6 +2,7 @@ from torch import nn, Tensor
 from typing import Iterable, Dict
 from torch.nn import functional as F
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -13,23 +14,27 @@ class MarginDistillationLoss(nn.Module):
 
     For an example, see the documentation on extending language models to new languages.
     """
-    def __init__(self, model, scale: float = 1.0, similarity_fct = 'dot'):
+
+    def __init__(self, model, scale: float = 1.0, similarity_fct="dot"):
         super(MarginDistillationLoss, self).__init__()
         self.model = model
         self.scale = scale
-        assert similarity_fct in ['dot', 'cos_sim']
+        assert similarity_fct in ["dot", "cos_sim"]
         self.similarity_fct = similarity_fct
-        logger.info(f'Set GPL score function to {similarity_fct}')
+        logger.info(f"Set GPL score function to {similarity_fct}")
         self.loss_fct = nn.MSELoss()
 
     def forward(self, sentence_features: Iterable[Dict[str, Tensor]], labels: Tensor):
         # sentence_features: query, positive passage, negative passage
-        reps = [self.model(sentence_feature)['sentence_embedding'] for sentence_feature in sentence_features]
+        reps = [
+            self.model(sentence_feature)["sentence_embedding"]
+            for sentence_feature in sentence_features
+        ]
         embeddings_query = reps[0]
         embeddings_pos = reps[1]
         embeddings_neg = reps[2]
 
-        if self.similarity_fct == 'cosine':
+        if self.similarity_fct == "cosine":
             embeddings_query = F.normalize(embeddings_query, dim=-1)
             embeddings_pos = F.normalize(embeddings_pos, dim=-1)
             embeddings_neg = F.normalize(embeddings_neg, dim=-1)

--- a/gpl/toolkit/mine.py
+++ b/gpl/toolkit/mine.py
@@ -9,47 +9,55 @@ import os
 import logging
 import argparse
 import time
+
 logger = logging.getLogger(__name__)
 
 
 class NegativeMiner(object):
-
     def __init__(
-        self, 
-        generated_path, 
-        prefix, 
-        retrievers=['bm25', 'msmarco-distilbert-base-v3', 'msmarco-MiniLM-L-6-v3'], 
-        retriever_score_functions=['none', 'cos_sim', 'cos_sim'],
+        self,
+        generated_path,
+        prefix,
+        retrievers=["bm25", "msmarco-distilbert-base-v3", "msmarco-MiniLM-L-6-v3"],
+        retriever_score_functions=["none", "cos_sim", "cos_sim"],
         nneg=50,
-        use_train_qrels: bool = False
+        use_train_qrels: bool = False,
     ):
         if use_train_qrels:
-            logger.info('Using labeled qrels to construct the hard-negative data')
-            self.corpus, self.gen_queries, self.gen_qrels = GenericDataLoader(generated_path).load(split="train")
+            logger.info("Using labeled qrels to construct the hard-negative data")
+            self.corpus, self.gen_queries, self.gen_qrels = GenericDataLoader(
+                generated_path
+            ).load(split="train")
         else:
-            self.corpus, self.gen_queries, self.gen_qrels = GenericDataLoader(generated_path, prefix=prefix).load(split="train")
-        self.output_path = os.path.join(generated_path, 'hard-negatives.jsonl')
+            self.corpus, self.gen_queries, self.gen_qrels = GenericDataLoader(
+                generated_path, prefix=prefix
+            ).load(split="train")
+        self.output_path = os.path.join(generated_path, "hard-negatives.jsonl")
         self.retrievers = retrievers
         self.retriever_score_functions = retriever_score_functions
-        if 'bm25' in retrievers:
-            assert nneg <= 10000, "Only `negatives_per_query` <= 10000 is acceptable by Elasticsearch-BM25"
-            assert retriever_score_functions[retrievers.index('bm25')] == 'none'
-        
-        assert set(retriever_score_functions).issubset({'none', 'dot', 'cos_sim'})
+        if "bm25" in retrievers:
+            assert (
+                nneg <= 10000
+            ), "Only `negatives_per_query` <= 10000 is acceptable by Elasticsearch-BM25"
+            assert retriever_score_functions[retrievers.index("bm25")] == "none"
+
+        assert set(retriever_score_functions).issubset({"none", "dot", "cos_sim"})
 
         self.nneg = nneg
         if nneg > len(self.corpus):
-            logger.warning("`negatives_per_query` > corpus size. Please use a smaller `negatives_per_query`")
+            logger.warning(
+                "`negatives_per_query` > corpus size. Please use a smaller `negatives_per_query`"
+            )
             self.nneg = len(self.corpus)
 
     def _get_doc(self, did):
-        return ' '.join([self.corpus[did]['title'], self.corpus[did]['text']])
-    
+        return " ".join([self.corpus[did]["title"], self.corpus[did]["text"]])
+
     def _mine_sbert(self, model_name, score_function):
-        logger.info(f'Mining with {model_name}')
-        assert score_function in ['dot', 'cos_sim']
+        logger.info(f"Mining with {model_name}")
+        assert score_function in ["dot", "cos_sim"]
         normalize_embeddings = False
-        if score_function == 'cos_sim':
+        if score_function == "cos_sim":
             normalize_embeddings = True
 
         result = {}
@@ -57,23 +65,23 @@ class NegativeMiner(object):
         docs = list(map(self._get_doc, self.corpus.keys()))
         dids = np.array(list(self.corpus.keys()))
         doc_embs = sbert.encode(
-            docs, 
-            batch_size=128, 
-            show_progress_bar=True, 
-            convert_to_numpy=False, 
+            docs,
+            batch_size=128,
+            show_progress_bar=True,
+            convert_to_numpy=False,
             convert_to_tensor=True,
-            normalize_embeddings=normalize_embeddings
+            normalize_embeddings=normalize_embeddings,
         )
         qids = list(self.gen_qrels.keys())
         queries = list(map(lambda qid: self.gen_queries[qid], qids))
         for start in tqdm.trange(0, len(queries), 128):
-            qid_batch = qids[start:start+128]
+            qid_batch = qids[start : start + 128]
             qemb_batch = sbert.encode(
-                queries[start:start+128], 
-                show_progress_bar=False, 
-                convert_to_numpy=False, 
+                queries[start : start + 128],
+                show_progress_bar=False,
+                convert_to_numpy=False,
                 convert_to_tensor=True,
-                normalize_embeddings=normalize_embeddings
+                normalize_embeddings=normalize_embeddings,
             )
             score_mtrx = torch.matmul(qemb_batch, doc_embs.t())  # (qsize, dsize)
             _, indices_topk = score_mtrx.topk(k=self.nneg, dim=-1)
@@ -85,14 +93,20 @@ class NegativeMiner(object):
                         neg_dids.remove(pos_did)
                 result[qid] = neg_dids
         return result
-    
+
     def _mine_bm25(self):
-        logger.info(f'Mining with bm25')
+        logger.info(f"Mining with bm25")
         result = {}
         docs = list(map(self._get_doc, self.corpus.keys()))
         dids = np.array(list(self.corpus.keys()))
         pool = dict(zip(dids, docs))
-        bm25 = ElasticSearchBM25(pool, port_http='9222', port_tcp='9333', service_type='executable', index_name=f'one_trial{int(time.time() * 1000000)}')
+        bm25 = ElasticSearchBM25(
+            pool,
+            port_http="9222",
+            port_tcp="9333",
+            service_type="executable",
+            index_name=f"one_trial{int(time.time() * 1000000)}",
+        )
         for qid, pos_dids in tqdm.tqdm(self.gen_qrels.items()):
             query = self.gen_queries[qid]
             rank = bm25.query(query, topk=self.nneg)  # topk should be <= 10000
@@ -105,35 +119,35 @@ class NegativeMiner(object):
 
     def run(self):
         hard_negatives = {}
-        for retriever, score_function in zip(self.retrievers, self.retriever_score_functions):
-            if retriever == 'bm25':
+        for retriever, score_function in zip(
+            self.retrievers, self.retriever_score_functions
+        ):
+            if retriever == "bm25":
                 hard_negatives[retriever] = self._mine_bm25()
             else:
                 hard_negatives[retriever] = self._mine_sbert(retriever, score_function)
-        
-        logger.info('Combining all the data')
+
+        logger.info("Combining all the data")
         result_jsonl = []
         for qid, pos_dids in tqdm.tqdm(self.gen_qrels.items()):
             line = {
-                'qid': qid,
-                'pos': list(pos_dids.keys()),
-                'neg': {
-                    k: v[qid] for k, v in hard_negatives.items()
-                }
+                "qid": qid,
+                "pos": list(pos_dids.keys()),
+                "neg": {k: v[qid] for k, v in hard_negatives.items()},
             }
             result_jsonl.append(line)
 
-        logger.info(f'Saving data to {self.output_path}')
-        with open(self.output_path, 'w') as f:
+        logger.info(f"Saving data to {self.output_path}")
+        with open(self.output_path, "w") as f:
             for line in result_jsonl:
-                f.write(json.dumps(line) + '\n')
-        logger.info('Done')
+                f.write(json.dumps(line) + "\n")
+        logger.info("Done")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--generated_path')
+    parser.add_argument("--generated_path")
     args = parser.parse_args()
 
-    miner = NegativeMiner(args.generated_path, 'qgen')
+    miner = NegativeMiner(args.generated_path, "qgen")
     miner.run()

--- a/gpl/toolkit/mnrl.py
+++ b/gpl/toolkit/mnrl.py
@@ -4,10 +4,19 @@ from sentence_transformers import SentenceTransformer, losses, models
 import os
 
 
-def mnrl(data_path, base_ckpt, output_dir, max_seq_length=350, use_amp=True, qgen_prefix='qgen'):
+def mnrl(
+    data_path,
+    base_ckpt,
+    output_dir,
+    max_seq_length=350,
+    use_amp=True,
+    qgen_prefix="qgen",
+):
     prefix = qgen_prefix
     #### Training on Generated Queries ####
-    corpus, gen_queries, gen_qrels = GenericDataLoader(data_path, prefix=prefix).load(split="train")
+    corpus, gen_queries, gen_qrels = GenericDataLoader(data_path, prefix=prefix).load(
+        split="train"
+    )
 
     #### Provide any HuggingFace model and fine-tune from scratch
     model_name = base_ckpt
@@ -32,9 +41,9 @@ def mnrl(data_path, base_ckpt, output_dir, max_seq_length=350, use_amp=True, qge
     warmup_steps = int(len(train_samples) * num_epochs / retriever.batch_size * 0.1)
 
     retriever.fit(
-        train_objectives=[(train_dataloader, train_loss)], 
+        train_objectives=[(train_dataloader, train_loss)],
         epochs=num_epochs,
         output_path=model_save_path,
         warmup_steps=warmup_steps,
-        use_amp=use_amp
+        use_amp=use_amp,
     )

--- a/gpl/toolkit/pl.py
+++ b/gpl/toolkit/pl.py
@@ -6,6 +6,7 @@ from transformers import AutoTokenizer
 import tqdm
 import os
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,39 +17,51 @@ def hard_negative_collate_fn(batch):
 
 
 class PseudoLabeler(object):
-
-    def __init__(self, generated_path, gen_queries, corpus, total_steps, batch_size, cross_encoder, max_seq_length):
-        assert 'hard-negatives.jsonl' in os.listdir(generated_path)
-        fpath_hard_negatives = os.path.join(generated_path, 'hard-negatives.jsonl')
+    def __init__(
+        self,
+        generated_path,
+        gen_queries,
+        corpus,
+        total_steps,
+        batch_size,
+        cross_encoder,
+        max_seq_length,
+    ):
+        assert "hard-negatives.jsonl" in os.listdir(generated_path)
+        fpath_hard_negatives = os.path.join(generated_path, "hard-negatives.jsonl")
         self.cross_encoder = CrossEncoder(cross_encoder)
-        hard_negative_dataset = HardNegativeDataset(fpath_hard_negatives, gen_queries, corpus)    
-        self.hard_negative_dataloader = DataLoader(hard_negative_dataset, shuffle=True, batch_size=batch_size, drop_last=True)
+        hard_negative_dataset = HardNegativeDataset(
+            fpath_hard_negatives, gen_queries, corpus
+        )
+        self.hard_negative_dataloader = DataLoader(
+            hard_negative_dataset, shuffle=True, batch_size=batch_size, drop_last=True
+        )
         self.hard_negative_dataloader.collate_fn = hard_negative_collate_fn
-        self.output_path = os.path.join(generated_path, 'gpl-training-data.tsv')
+        self.output_path = os.path.join(generated_path, "gpl-training-data.tsv")
         self.total_steps = total_steps
-        
+
         #### retokenization
         self.retokenizer = AutoTokenizer.from_pretrained(cross_encoder)
         self.max_seq_length = max_seq_length
-    
+
     def retokenize(self, texts):
         ## We did this retokenization for two reasons:
         ### (1) Setting the max_seq_length;
-        ### (2) We cannot simply use CrossEncoder(cross_encoder, max_length=max_seq_length), 
-        ##### since the max_seq_length will then be reflected on the concatenated sequence, 
+        ### (2) We cannot simply use CrossEncoder(cross_encoder, max_length=max_seq_length),
+        ##### since the max_seq_length will then be reflected on the concatenated sequence,
         ##### rather than the two sequences independently
         texts = list(map(lambda text: text.strip(), texts))
         features = self.retokenizer(
-            texts, 
-            padding=True, 
-            truncation='longest_first', 
-            return_tensors="pt", 
-            max_length=self.max_seq_length
+            texts,
+            padding=True,
+            truncation="longest_first",
+            return_tensors="pt",
+            max_length=self.max_seq_length,
         )
         decoded = self.retokenizer.batch_decode(
-            features['input_ids'],
+            features["input_ids"],
             skip_special_tokens=True,
-            clean_up_tokenization_spaces=True
+            clean_up_tokenization_spaces=True,
         )
         return decoded
 
@@ -57,7 +70,7 @@ class PseudoLabeler(object):
         data = []
 
         hard_negative_iterator = iter(self.hard_negative_dataloader)
-        logger.info('Begin pseudo labeling')
+        logger.info("Begin pseudo labeling")
         for _ in tqdm.trange(self.total_steps):
             try:
                 batch = next(hard_negative_iterator)
@@ -68,17 +81,21 @@ class PseudoLabeler(object):
             (query_id, pos_id, neg_id), (query, pos, neg) = batch
             query, pos, neg = [self.retokenize(texts) for texts in [query, pos, neg]]
             scores = self.cross_encoder.predict(
-                list(zip(query, pos)) + list(zip(query, neg)), 
-                show_progress_bar=False
+                list(zip(query, pos)) + list(zip(query, neg)), show_progress_bar=False
             )
-            labels = scores[:len(query)] - scores[len(query):]
-            labels = labels.tolist()  # Using `tolist` will keep more precision digits!!!
-            
-            batch_gpl = map(lambda quad: '\t'.join((*quad[:3], str(quad[3]))) + '\n', zip(query_id, pos_id, neg_id, labels))
+            labels = scores[: len(query)] - scores[len(query) :]
+            labels = (
+                labels.tolist()
+            )  # Using `tolist` will keep more precision digits!!!
+
+            batch_gpl = map(
+                lambda quad: "\t".join((*quad[:3], str(quad[3]))) + "\n",
+                zip(query_id, pos_id, neg_id, labels),
+            )
             data.extend(batch_gpl)
-        
-        logger.info('Done pseudo labeling and saving data')
-        with open(self.output_path, 'w') as f:
+
+        logger.info("Done pseudo labeling and saving data")
+        with open(self.output_path, "w") as f:
             f.writelines(data)
-        
-        logger.info(f'Saved GPL-training data to {self.output_path}')
+
+        logger.info(f"Saved GPL-training data to {self.output_path}")

--- a/gpl/toolkit/qgen.py
+++ b/gpl/toolkit/qgen.py
@@ -5,11 +5,18 @@ import os
 import argparse
 
 
-def qgen(data_path, output_dir, generator_name_or_path='BeIR/query-gen-msmarco-t5-base-v1', ques_per_passage=3, bsz=32, qgen_prefix='qgen'):
+def qgen(
+    data_path,
+    output_dir,
+    generator_name_or_path="BeIR/query-gen-msmarco-t5-base-v1",
+    ques_per_passage=3,
+    bsz=32,
+    qgen_prefix="qgen",
+):
     #### Provide the data_path where nfcorpus has been downloaded and unzipped
     corpus = GenericDataLoader(data_path).load_corpus()
 
-    #### question-generation model loading 
+    #### question-generation model loading
     generator = QGen(model=QGenModel(generator_name_or_path))
 
     #### Query-Generation using Nucleus Sampling (top_k=25, top_p=0.95) ####
@@ -17,18 +24,23 @@ def qgen(data_path, output_dir, generator_name_or_path='BeIR/query-gen-msmarco-t
     #### Prefix is required to seperate out synthetic queries and qrels from original
     prefix = qgen_prefix
 
-    #### Generating 3 questions per passage. 
+    #### Generating 3 questions per passage.
     #### Reminder the higher value might produce lots of duplicates
     #### Generate queries per passage from docs in corpus and save them in data_path
-    generator.generate(corpus, output_dir=output_dir, ques_per_passage=ques_per_passage, prefix=prefix, batch_size=bsz)
-    if not os.path.exists(os.path.join(output_dir, 'corpus.jsonl')):
-        os.system(f'cp {data_path}/corpus.jsonl {output_dir}')
+    generator.generate(
+        corpus,
+        output_dir=output_dir,
+        ques_per_passage=ques_per_passage,
+        prefix=prefix,
+        batch_size=bsz,
+    )
+    if not os.path.exists(os.path.join(output_dir, "corpus.jsonl")):
+        os.system(f"cp {data_path}/corpus.jsonl {output_dir}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--data_path', required=True)
-    parser.add_argument('--output_dir', required=True)
+    parser.add_argument("--data_path", required=True)
+    parser.add_argument("--output_dir", required=True)
     args = parser.parse_args()
     qgen(args.data_path, args.output_dir)
-    

--- a/gpl/toolkit/reformat.py
+++ b/gpl/toolkit/reformat.py
@@ -6,6 +6,7 @@ from transformers.models.bert.modeling_bert import BertPooler
 from gpl.toolkit import directly_loadable_by_sbert
 import argparse
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -13,29 +14,36 @@ def simcse_like(model_name_or_path, output_path):
     ## For simcse-like models (e.g. "princeton-nlp/sup-simcse-bert-base-uncased"), the last layer is a linear layer on top of the CLS token embedding
     word_embedding_model = models.Transformer(model_name_or_path)
     auto_model = word_embedding_model.auto_model
-    assert hasattr(auto_model, 'pooler'), 'This checkpoint (originally in HF-format) cannot be transformed into SBERT-format by this example method'
+    assert hasattr(
+        auto_model, "pooler"
+    ), "This checkpoint (originally in HF-format) cannot be transformed into SBERT-format by this example method"
     pooler: BertPooler = auto_model.pooler  # This is the last layer, a linear mapping
-    pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension(), pooling_mode='cls')
+    pooling_model = models.Pooling(
+        word_embedding_model.get_word_embedding_dimension(), pooling_mode="cls"
+    )
     dense = models.Dense(
-        in_features=pooler.dense.in_features, 
-        out_features=pooler.dense.out_features, 
-        init_weight=pooler.dense.weight, 
+        in_features=pooler.dense.in_features,
+        out_features=pooler.dense.out_features,
+        init_weight=pooler.dense.weight,
         init_bias=pooler.dense.bias,
-        activation_function=pooler.activation
+        activation_function=pooler.activation,
     )
     model = SentenceTransformer(modules=[word_embedding_model, pooling_model, dense])
-    assert directly_loadable_by_sbert(model), 'Cannot transform it into SBERT-format'
+    assert directly_loadable_by_sbert(model), "Cannot transform it into SBERT-format"
     model.save_model(output_path)
+
 
 def dpr_like(model_name_or_path, output_path):
     ## For dpr-like models (e.g. "facebook/dpr-question_encoder-single-nq-base"), the last layer is also a linear layer on top of the CLS token embedding, but it does not output hidden states
     def down_to_pooler(model: PreTrainedModel):
         ## For "facebook/dpr-question_encoder-single-nq-base", the pooler is not directly accessible
         ## One needs to go through: DPRQuestionEncoder -> DPREncoder -> BertModel -> BertPooler
-        if hasattr(model, 'pooler'):
+        if hasattr(model, "pooler"):
             return model, model.pooler
         else:
-            assert len(model._modules) == 1, 'This checkpoint does not have a pooler and thus cannot be transformed into SBERT-format in a naive way'
+            assert (
+                len(model._modules) == 1
+            ), "This checkpoint does not have a pooler and thus cannot be transformed into SBERT-format in a naive way"
             next_module = list(model._modules)[0]
             return down_to_pooler(getattr(model, next_module))
 
@@ -43,33 +51,41 @@ def dpr_like(model_name_or_path, output_path):
     auto_model = word_embedding_model.auto_model
     model_and_pooler = down_to_pooler(auto_model)  # Get the model and pooler
     auto_model: BertModel = model_and_pooler[0]
-    ## TODO: Infer config class automatically    
+    ## TODO: Infer config class automatically
     auto_model.config = BertConfig()  # Change DPRConfig into BertConfig
     pooler: BertPooler = model_and_pooler[1]
     word_embedding_model.auto_model = auto_model
-    pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension(), pooling_mode='cls')
+    pooling_model = models.Pooling(
+        word_embedding_model.get_word_embedding_dimension(), pooling_mode="cls"
+    )
     dense = models.Dense(
-        in_features=pooler.dense.in_features, 
-        out_features=pooler.dense.out_features, 
-        init_weight=pooler.dense.weight, 
+        in_features=pooler.dense.in_features,
+        out_features=pooler.dense.out_features,
+        init_weight=pooler.dense.weight,
         init_bias=pooler.dense.bias,
-        activation_function=pooler.activation
+        activation_function=pooler.activation,
     )
     model = SentenceTransformer(modules=[word_embedding_model, pooling_model, dense])
-    assert directly_loadable_by_sbert(model), 'Cannot transform it into SBERT-format'
+    assert directly_loadable_by_sbert(model), "Cannot transform it into SBERT-format"
     model.save(output_path)
 
-templates = {
-    'simcse_like': simcse_like,
-    'dpr_like': dpr_like
-}
 
-if __name__ == '__main__':
+templates = {"simcse_like": simcse_like, "dpr_like": dpr_like}
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--template', required=True, choices=list(templates.keys()), help='Selecting one template and do the reformatting (from HF-format to SBERT-format)')
-    parser.add_argument('--model_name_or_path', help='The checkpoint in HF-format, which is going to be reformatted')
-    parser.add_argument('--output_path', help='Output path to the reformatted checkpoint')
+    parser.add_argument(
+        "--template",
+        required=True,
+        choices=list(templates.keys()),
+        help="Selecting one template and do the reformatting (from HF-format to SBERT-format)",
+    )
+    parser.add_argument(
+        "--model_name_or_path",
+        help="The checkpoint in HF-format, which is going to be reformatted",
+    )
+    parser.add_argument(
+        "--output_path", help="Output path to the reformatted checkpoint"
+    )
     args = parser.parse_args()
     templates[args.template](args.model_name_or_path, args.output_path)
-    
-

--- a/gpl/toolkit/rescale.py
+++ b/gpl/toolkit/rescale.py
@@ -2,6 +2,7 @@ from cmath import log
 import os
 import shutil
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,40 +17,47 @@ def rescale_fn(margin, org_min, org_max, new_min, new_max):
         org_max = 0
         new_max = 0
 
-    new_margin = new_min + (margin - org_min) * (new_max - new_min) / (org_max - org_min)
+    new_margin = new_min + (margin - org_min) * (new_max - new_min) / (
+        org_max - org_min
+    )
     return new_margin
 
 
-def rescale_gpl_training_data(data_dir: str, new_min: float, new_max: float, suffix='rescaled'):
-    gpl_training_data_name = 'gpl-training-data.tsv'
+def rescale_gpl_training_data(
+    data_dir: str, new_min: float, new_max: float, suffix="rescaled"
+):
+    gpl_training_data_name = "gpl-training-data.tsv"
     assert gpl_training_data_name in os.listdir(data_dir)
     fpath = os.path.join(data_dir, gpl_training_data_name)
     margins = []
-    with open(fpath, 'r') as f:
+    with open(fpath, "r") as f:
         for i, line in enumerate(f):
-            margin = float(line.strip().split('\t')[-1])
+            margin = float(line.strip().split("\t")[-1])
             margins.append(margin)
-    org_min, org_max = min(margins), max(margins)  # TODO: Try points at 5% and 95% percentiles
+    org_min, org_max = min(margins), max(
+        margins
+    )  # TODO: Try points at 5% and 95% percentiles
     assert org_min != org_max
 
-    frescaled = f'gpl-training-data.{suffix}.tsv'
+    frescaled = f"gpl-training-data.{suffix}.tsv"
     fpath_rescaled = os.path.join(data_dir, frescaled)
     if os.path.exists(fpath_rescaled):
-        logger.info('Found the rescaled data has already existed. Escaped rescaling')
+        logger.info("Found the rescaled data has already existed. Escaped rescaling")
         return frescaled
 
-    with open(fpath, 'r') as fin, open(fpath_rescaled, 'w') as fout:
+    with open(fpath, "r") as fin, open(fpath_rescaled, "w") as fout:
         for line in fin:
-            items = line.strip().split('\t')
+            items = line.strip().split("\t")
             margin = float(items[-1])
 
-            # rescaling:            
+            # rescaling:
             new_margin = rescale_fn(margin, org_min, org_max, new_min, new_max)
 
             items[-1] = str(new_margin)
-            line = '\t'.join(items) + '\n'
+            line = "\t".join(items) + "\n"
             fout.write(line)
 
-    logger.info(f'Rescaled the pseudo labels to range [{new_min}, {new_max}] from the original range [{org_min}, {org_max}]. The output is {fpath_rescaled}')
+    logger.info(
+        f"Rescaled the pseudo labels to range [{new_min}, {new_max}] from the original range [{org_min}, {org_max}]. The output is {fpath_rescaled}"
+    )
     return frescaled
-

--- a/gpl/toolkit/resize.py
+++ b/gpl/toolkit/resize.py
@@ -5,18 +5,19 @@ import random
 import os
 import json
 import logging
+
 logger = logging.getLogger(__name__)
 
 
-def resize(data_path, output_path, new_size, use_train_qrels:bool = False):
+def resize(data_path, output_path, new_size, use_train_qrels: bool = False):
     train_qrels = None
     if use_train_qrels:
-        corpus, _, train_qrels = GenericDataLoader(data_path).load(split='train')
+        corpus, _, train_qrels = GenericDataLoader(data_path).load(split="train")
     else:
         corpus = GenericDataLoader(data_path).load_corpus()
-    
+
     if len(corpus) <= new_size:
-        logger.warning('`new_size` should be smaller than the corpus size')
+        logger.warning("`new_size` should be smaller than the corpus size")
         corpus_new = list(corpus.items())
     else:
         corpus_new = random.sample(list(corpus.items()), k=new_size)
@@ -32,12 +33,16 @@ def resize(data_path, output_path, new_size, use_train_qrels:bool = False):
                     nadded += 1
 
     os.makedirs(output_path, exist_ok=True)
-    with open(os.path.join(output_path, 'corpus.jsonl'), 'w') as f:
+    with open(os.path.join(output_path, "corpus.jsonl"), "w") as f:
         for doc_id, doc in corpus_new.items():
-            doc['_id'] = doc_id
-            f.write(json.dumps(doc) + '\n') 
-    
+            doc["_id"] = doc_id
+            f.write(json.dumps(doc) + "\n")
+
     if not nadded:
-        logger.info(f'Resized the corpus in {data_path} to {output_path} with new size {new_size}')
+        logger.info(
+            f"Resized the corpus in {data_path} to {output_path} with new size {new_size}"
+        )
     else:
-        logger.info(f'Resized the corpus in {data_path} to {output_path} with new size {new_size} + {nadded} (including the documents mentioned in the train qrels)')
+        logger.info(
+            f"Resized the corpus in {data_path} to {output_path} with new size {new_size} + {nadded} (including the documents mentioned in the train qrels)"
+        )

--- a/gpl/toolkit/sbert.py
+++ b/gpl/toolkit/sbert.py
@@ -1,20 +1,24 @@
 from sentence_transformers import SentenceTransformer, models
 import logging
+
 logger = logging.getLogger(__name__)
 
 
 def directly_loadable_by_sbert(model: SentenceTransformer):
     loadable_by_sbert = True
     try:
-        texts = ['This is an input text',]
+        texts = [
+            "This is an input text",
+        ]
         model.encode(texts)
     except RuntimeError:
         loadable_by_sbert = False
     return loadable_by_sbert
 
+
 def load_sbert(model_name_or_path, pooling=None, max_seq_length=None):
     model = SentenceTransformer(model_name_or_path)
-    
+
     ## Check whether SBERT can load the checkpoint and use it
     loadable_by_sbert = directly_loadable_by_sbert(model)
     if loadable_by_sbert:
@@ -23,24 +27,41 @@ def load_sbert(model_name_or_path, pooling=None, max_seq_length=None):
         ## NOTICE: Even for (2), there might be some checkpoints (e.g. "princeton-nlp/sup-simcse-bert-base-uncased") that uses a linear layer on top of the CLS token embedding to get the final dense representation. In this case, setting `--pooling` to a specify pooling method will misuse the checkpoint. This is why we recommend to use SBERT-format if possible
         ## Setting pooling if needed
         if pooling is not None:
-            logger.warning(f'Trying setting pooling method manually (`--pooling={pooling}`). Recommand to use a checkpoint in SBERT-format and leave the `--pooling=None`: This is less likely to misuse the pooling')
+            logger.warning(
+                f"Trying setting pooling method manually (`--pooling={pooling}`). Recommand to use a checkpoint in SBERT-format and leave the `--pooling=None`: This is less likely to misuse the pooling"
+            )
             last_layer: models.Pooling = model[-1]
-            assert type(last_layer) == models.Pooling, f'The last layer is not a pooling layer and thus `--pooling={pooling}` cannot work. Please try leaving `--pooling=None` as in the default setting'
+            assert (
+                type(last_layer) == models.Pooling
+            ), f"The last layer is not a pooling layer and thus `--pooling={pooling}` cannot work. Please try leaving `--pooling=None` as in the default setting"
             # We here change the pooling by building the whole SBERT model again, which is safer and more maintainable than setting the attributes of the Pooling module
-            word_embedding_model = models.Transformer(model_name_or_path, max_seq_length=max_seq_length)
-            pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension(), pooling_mode=pooling)
+            word_embedding_model = models.Transformer(
+                model_name_or_path, max_seq_length=max_seq_length
+            )
+            pooling_model = models.Pooling(
+                word_embedding_model.get_word_embedding_dimension(),
+                pooling_mode=pooling,
+            )
             model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
     else:
         ## Not directly loadable by SBERT
         ## Mainly one case: The last layer is a linear layer (e.g. "facebook/dpr-question_encoder-single-nq-base")
-        raise NotImplementedError('This checkpoint cannot be directly loadable by SBERT. Please transform it into SBERT-format first and then try again. Please pay attention to its last layer')
+        raise NotImplementedError(
+            "This checkpoint cannot be directly loadable by SBERT. Please transform it into SBERT-format first and then try again. Please pay attention to its last layer"
+        )
 
     ## Setting max_seq_length if needed
     if max_seq_length is not None:
         first_layer: models.Transformer = model[0]
-        assert type(first_layer) == models.Transformer, 'Unknown error, please report this'
-        assert hasattr(first_layer, 'max_seq_length'), 'Unknown error, please report this'
-        setattr(first_layer, 'max_seq_length', max_seq_length)  # Set the maximum-sequence length
-        logger.info(f'Set max_seq_length={max_seq_length}')
-        
+        assert (
+            type(first_layer) == models.Transformer
+        ), "Unknown error, please report this"
+        assert hasattr(
+            first_layer, "max_seq_length"
+        ), "Unknown error, please report this"
+        setattr(
+            first_layer, "max_seq_length", max_seq_length
+        )  # Set the maximum-sequence length
+        logger.info(f"Set max_seq_length={max_seq_length}")
+
     return model

--- a/gpl/train.py
+++ b/gpl/train.py
@@ -1,20 +1,20 @@
 import shutil
 from beir.datasets.data_loader import GenericDataLoader
 from .toolkit import (
-    qgen, 
-    NegativeMiner, 
-    MarginDistillationLoss, 
-    GenerativePseudoLabelingDataset, 
-    PseudoLabeler, 
-    evaluate, 
-    resize, 
-    load_sbert, 
-    set_logger_format, 
-    mnrl, 
-    save_queries, 
-    save_qrels, 
+    qgen,
+    NegativeMiner,
+    MarginDistillationLoss,
+    GenerativePseudoLabelingDataset,
+    PseudoLabeler,
+    evaluate,
+    resize,
+    load_sbert,
+    set_logger_format,
+    mnrl,
+    save_queries,
+    save_qrels,
     extract_queries_split,
-    rescale_gpl_training_data
+    rescale_gpl_training_data,
 )
 from sentence_transformers import SentenceTransformer
 from torch.utils.data import DataLoader
@@ -23,11 +23,14 @@ import logging
 import argparse
 from typing import List, Union
 import math
+
 # import crash_ipdb
 
 
 set_logger_format()
-logger = logging.getLogger('gpl.train')  # Here we do not use __name__ to have unified logger name, no matter whether we are using `python -m` or `import gpl; gpl.train`
+logger = logging.getLogger(
+    "gpl.train"
+)  # Here we do not use __name__ to have unified logger name, no matter whether we are using `python -m` or `import gpl; gpl.train`
 
 
 def train(
@@ -37,11 +40,11 @@ def train(
     mnrl_evaluation_output: str = None,
     do_evaluation: str = False,
     evaluation_data: str = None,
-    evaluation_output: str = 'output',
-    qgen_prefix: str = 'qgen',
-    base_ckpt: str = 'distilbert-base-uncased',
-    generator: str = 'BeIR/query-gen-msmarco-t5-base-v1',
-    cross_encoder: str = 'cross-encoder/ms-marco-MiniLM-L-6-v2',
+    evaluation_output: str = "output",
+    qgen_prefix: str = "qgen",
+    base_ckpt: str = "distilbert-base-uncased",
+    generator: str = "BeIR/query-gen-msmarco-t5-base-v1",
+    cross_encoder: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
     batch_size_gpl: int = 32,
     batch_size_generation: int = 32,
     pooling: str = None,
@@ -50,134 +53,205 @@ def train(
     queries_per_passage: int = 3,
     gpl_steps: int = 140000,
     use_amp: bool = False,
-    retrievers: List[str] = ['msmarco-distilbert-base-v3', 'msmarco-MiniLM-L-6-v3'],
-    retriever_score_functions: List[str] = ['cos_sim', 'cos_sim'],
+    retrievers: List[str] = ["msmarco-distilbert-base-v3", "msmarco-MiniLM-L-6-v3"],
+    retriever_score_functions: List[str] = ["cos_sim", "cos_sim"],
     negatives_per_query: int = 50,
-    eval_split: str = 'test',
+    eval_split: str = "test",
     use_train_qrels: bool = False,
-    gpl_score_function: str = 'dot',
-    rescale_range: List[float] = None
-):     
+    gpl_score_function: str = "dot",
+    rescale_range: List[float] = None,
+):
     #### Assertions ####
-    assert pooling in [None, 'mean', 'cls', 'max']
+    assert pooling in [None, "mean", "cls", "max"]
     if do_evaluation:
         assert evaluation_data is not None
         assert evaluation_output is not None
         try:
             GenericDataLoader(evaluation_data)
         except Exception as e:
-            logger.error('Cannot load evaluation data for evaluation usage.')
+            logger.error("Cannot load evaluation data for evaluation usage.")
             raise e
     if new_size is not None and new_size != -1:
         assert new_size * queries_per_passage >= batch_size_gpl
-    
 
     #### Make sure there is a `corpus.jsonl` file. It should be under either `path_to_generated_data` or `evaluation_data`` ####
     #### Also resize the corpus for efficient training if required  ####
     os.makedirs(path_to_generated_data, exist_ok=True)
-    if 'corpus.jsonl' not in os.listdir(path_to_generated_data):
-        logger.info(f'Corpus does not exist in {path_to_generated_data}. Now clone the one from the evaluation path {evaluation_data}')
-        assert 'corpus.jsonl' in os.listdir(evaluation_data), f'No corpus found in evaluation path {evaluation_data}! It should be in the BeIR format. For more details, please refer to https://github.com/UKPLab/beir#beers-available-datasets.'
+    if "corpus.jsonl" not in os.listdir(path_to_generated_data):
+        logger.info(
+            f"Corpus does not exist in {path_to_generated_data}. Now clone the one from the evaluation path {evaluation_data}"
+        )
+        assert "corpus.jsonl" in os.listdir(
+            evaluation_data
+        ), f"No corpus found in evaluation path {evaluation_data}! It should be in the BeIR format. For more details, please refer to https://github.com/UKPLab/beir#beers-available-datasets."
         if new_size is not None:
             if new_size == -1:
-                new_size = math.ceil(250e3 / 3)  # Here use ceil to make the QPP == 3 if the corpus is large enough
-                logger.info(f'Automatically set `new_size` to {new_size}')
+                new_size = math.ceil(
+                    250e3 / 3
+                )  # Here use ceil to make the QPP == 3 if the corpus is large enough
+                logger.info(f"Automatically set `new_size` to {new_size}")
             resize(evaluation_data, path_to_generated_data, new_size, use_train_qrels)
         else:
-            corpus_path = os.path.join(evaluation_data, 'corpus.jsonl')
-            os.system(f'cp {corpus_path} {path_to_generated_data}')
-    
+            corpus_path = os.path.join(evaluation_data, "corpus.jsonl")
+            os.system(f"cp {corpus_path} {path_to_generated_data}")
 
     #### Adjust the QQP automatically, if needed ####
     if queries_per_passage == -1:
-        assert 'corpus.jsonl' in os.listdir(path_to_generated_data), 'At least corpus should exist!'
+        assert "corpus.jsonl" in os.listdir(
+            path_to_generated_data
+        ), "At least corpus should exist!"
         corpus = GenericDataLoader(path_to_generated_data).load_corpus()
         if len(corpus) * 3 < 250e3:
-            queries_per_passage = math.ceil(250e3 / len(corpus))  # Here use ceil to guarantee the QPP will not be too small
+            queries_per_passage = math.ceil(
+                250e3 / len(corpus)
+            )  # Here use ceil to guarantee the QPP will not be too small
         else:
             queries_per_passage = 3
-        logger.info(f'Automatically set `queries_per_passage` to {queries_per_passage}')
-
+        logger.info(f"Automatically set `queries_per_passage` to {queries_per_passage}")
 
     #### Synthetic query generation ####
     #### This will be skipped if there is an existing `gen-queries.jsonl`file under `path_to_generated_data` ####
     if use_train_qrels == True:
         if qgen_prefix is not None:
-                logger.warning('Found `qgen_prefix` is not None. By setting `use_train_qrels == True`, the `qgen_prefix` will not be used')
+            logger.warning(
+                "Found `qgen_prefix` is not None. By setting `use_train_qrels == True`, the `qgen_prefix` will not be used"
+            )
 
-        if 'qrels' in os.listdir(path_to_generated_data) and 'queries.jsonl' in os.listdir(path_to_generated_data):
-            logger.info('Loading from existing labeled data')
-            corpus, gen_queries, gen_qrels = GenericDataLoader(path_to_generated_data).load(split="train")
+        if "qrels" in os.listdir(
+            path_to_generated_data
+        ) and "queries.jsonl" in os.listdir(path_to_generated_data):
+            logger.info("Loading from existing labeled data")
+            corpus, gen_queries, gen_qrels = GenericDataLoader(
+                path_to_generated_data
+            ).load(split="train")
         else:
-            assert evaluation_data is not None, "To use this feature `use_train_qrels == True`, please specify the `evaluation_data`, which should contain the labeled queries and qrels"
-            logger.info('Loading qrels and queries from labeled data under the path of `evaluation_data`')
-            assert 'qrels' in os.listdir(evaluation_data) and 'queries.jsonl' in os.listdir(evaluation_data)
-            assert 'train.tsv' in os.listdir(os.path.join(evaluation_data, 'qrels'))
-            corpus, all_queries, train_qrels = GenericDataLoader(evaluation_data).load(split='train')  # TODO: Change the variable name `gen_queries`
+            assert (
+                evaluation_data is not None
+            ), "To use this feature `use_train_qrels == True`, please specify the `evaluation_data`, which should contain the labeled queries and qrels"
+            logger.info(
+                "Loading qrels and queries from labeled data under the path of `evaluation_data`"
+            )
+            assert "qrels" in os.listdir(
+                evaluation_data
+            ) and "queries.jsonl" in os.listdir(evaluation_data)
+            assert "train.tsv" in os.listdir(os.path.join(evaluation_data, "qrels"))
+            corpus, all_queries, train_qrels = GenericDataLoader(evaluation_data).load(
+                split="train"
+            )  # TODO: Change the variable name `gen_queries`
             train_queries = extract_queries_split(all_queries, train_qrels)
-            save_queries(train_queries, path_to_generated_data)  # Copy the training data into the `path_to_generated_data` folder,
-            save_qrels(train_qrels, path_to_generated_data, split='train')  # then the negative miner can load it and run mining thereon
-            gen_queries = train_queries  # This variable will be passed into the PseudoLabeler
-    elif f'{qgen_prefix}-qrels' in os.listdir(path_to_generated_data) and f'{qgen_prefix}-queries.jsonl' in os.listdir(path_to_generated_data):
-        logger.info('Loading from existing generated data')
-        corpus, gen_queries, gen_qrels = GenericDataLoader(path_to_generated_data, prefix=qgen_prefix).load(split="train")
+            save_queries(
+                train_queries, path_to_generated_data
+            )  # Copy the training data into the `path_to_generated_data` folder,
+            save_qrels(
+                train_qrels, path_to_generated_data, split="train"
+            )  # then the negative miner can load it and run mining thereon
+            gen_queries = (
+                train_queries  # This variable will be passed into the PseudoLabeler
+            )
+    elif f"{qgen_prefix}-qrels" in os.listdir(
+        path_to_generated_data
+    ) and f"{qgen_prefix}-queries.jsonl" in os.listdir(path_to_generated_data):
+        logger.info("Loading from existing generated data")
+        corpus, gen_queries, gen_qrels = GenericDataLoader(
+            path_to_generated_data, prefix=qgen_prefix
+        ).load(split="train")
     else:
-        logger.info('No generated queries found. Now generating it')
-        assert 'corpus.jsonl' in os.listdir(path_to_generated_data), 'At least corpus should exist!'
-        qgen(path_to_generated_data, path_to_generated_data, generator_name_or_path=generator, ques_per_passage=queries_per_passage, bsz=batch_size_generation, qgen_prefix=qgen_prefix)
-        corpus, gen_queries, gen_qrels = GenericDataLoader(path_to_generated_data, prefix=qgen_prefix).load(split="train")
-
+        logger.info("No generated queries found. Now generating it")
+        assert "corpus.jsonl" in os.listdir(
+            path_to_generated_data
+        ), "At least corpus should exist!"
+        qgen(
+            path_to_generated_data,
+            path_to_generated_data,
+            generator_name_or_path=generator,
+            ques_per_passage=queries_per_passage,
+            bsz=batch_size_generation,
+            qgen_prefix=qgen_prefix,
+        )
+        corpus, gen_queries, gen_qrels = GenericDataLoader(
+            path_to_generated_data, prefix=qgen_prefix
+        ).load(split="train")
 
     #### Hard-negative mining ####
     #### This will be skipped if there is an existing `hard-negatives.jsonl` file under `path_to_generated_data` ####
-    if 'hard-negatives.jsonl' in os.listdir(path_to_generated_data):
-        logger.info('Using exisiting hard-negative data')
-    else: 
-        logger.info('No hard-negative data found. Now mining it')
-        miner = NegativeMiner(path_to_generated_data, qgen_prefix, retrievers=retrievers, retriever_score_functions=retriever_score_functions, nneg=negatives_per_query, use_train_qrels=use_train_qrels)
+    if "hard-negatives.jsonl" in os.listdir(path_to_generated_data):
+        logger.info("Using exisiting hard-negative data")
+    else:
+        logger.info("No hard-negative data found. Now mining it")
+        miner = NegativeMiner(
+            path_to_generated_data,
+            qgen_prefix,
+            retrievers=retrievers,
+            retriever_score_functions=retriever_score_functions,
+            nneg=negatives_per_query,
+            use_train_qrels=use_train_qrels,
+        )
         miner.run()
-
 
     #### Pseudo labeling ####
     #### This will be skipped if there is an existing `gpl-training-data.tsv` file under `path_to_generated_data` ####
-    gpl_training_data_fname = 'gpl-training-data.tsv'
+    gpl_training_data_fname = "gpl-training-data.tsv"
     if gpl_training_data_fname in os.listdir(path_to_generated_data):
-        logger.info('Using existing GPL-training data')
+        logger.info("Using existing GPL-training data")
     else:
-        logger.info('No GPL-training data found. Now generating it via pseudo labeling')
-        pseudo_labeler = PseudoLabeler(path_to_generated_data, gen_queries, corpus, gpl_steps, batch_size_gpl, cross_encoder, max_seq_length)
+        logger.info("No GPL-training data found. Now generating it via pseudo labeling")
+        pseudo_labeler = PseudoLabeler(
+            path_to_generated_data,
+            gen_queries,
+            corpus,
+            gpl_steps,
+            batch_size_gpl,
+            cross_encoder,
+            max_seq_length,
+        )
         pseudo_labeler.run()
     # Do rescaling if needed:
     if rescale_range is not None and len(rescale_range) == 2:
-        if gpl_score_function != 'cos_sim':
-            logger.warning(f'Doing rescaling while gpl_score_function = {gpl_score_function}')
+        if gpl_score_function != "cos_sim":
+            logger.warning(
+                f"Doing rescaling while gpl_score_function = {gpl_score_function}"
+            )
 
         new_min, new_max = rescale_range
-        logger.info(f'Doing rescaling with new range [{new_min}, {new_max}]')
-        gpl_training_data_fname = rescale_gpl_training_data(path_to_generated_data, new_min, new_max)  # This will rescale the margins and generate a new file
+        logger.info(f"Doing rescaling with new range [{new_min}, {new_max}]")
+        gpl_training_data_fname = rescale_gpl_training_data(
+            path_to_generated_data, new_min, new_max
+        )  # This will rescale the margins and generate a new file
     else:
         # if len(rescale_range) != 2:
         #     logger.warning(f'len(rescale_range) should be 2')
-        if gpl_score_function == 'cos_sim':
-            logger.warning(f'Not do rescaling while gpl_score_function = {gpl_score_function}')
+        if gpl_score_function == "cos_sim":
+            logger.warning(
+                f"Not do rescaling while gpl_score_function = {gpl_score_function}"
+            )
 
     ### Train the model with MarginMSE loss ###
     #### This will be skipped if the checkpoint at the indicated training steps can be found ####
     ckpt_dir = os.path.join(output_dir, str(gpl_steps))
-    if not os.path.exists(ckpt_dir) or (os.path.exists(ckpt_dir) and not os.listdir(ckpt_dir)):
-        logger.info('Now doing training on the generated data with the MarginMSE loss')
+    if not os.path.exists(ckpt_dir) or (
+        os.path.exists(ckpt_dir) and not os.listdir(ckpt_dir)
+    ):
+        logger.info("Now doing training on the generated data with the MarginMSE loss")
         #### It can load checkpoints in both SBERT-format (recommended) and Huggingface-format
         model: SentenceTransformer = load_sbert(base_ckpt, pooling, max_seq_length)
 
         fpath_gpl_data = os.path.join(path_to_generated_data, gpl_training_data_fname)
-        logger.info(f'Load GPL training data from {fpath_gpl_data}')
-        train_dataset = GenerativePseudoLabelingDataset(fpath_gpl_data, gen_queries, corpus)
-        train_dataloader = DataLoader(train_dataset, shuffle=False, batch_size=batch_size_gpl, drop_last=True)  # Here shuffle=False, since (or assuming) we have done it in the pseudo labeling
-        train_loss = MarginDistillationLoss(model=model, similarity_fct=gpl_score_function)
+        logger.info(f"Load GPL training data from {fpath_gpl_data}")
+        train_dataset = GenerativePseudoLabelingDataset(
+            fpath_gpl_data, gen_queries, corpus
+        )
+        train_dataloader = DataLoader(
+            train_dataset, shuffle=False, batch_size=batch_size_gpl, drop_last=True
+        )  # Here shuffle=False, since (or assuming) we have done it in the pseudo labeling
+        train_loss = MarginDistillationLoss(
+            model=model, similarity_fct=gpl_score_function
+        )
 
         # assert gpl_steps > 1000
         model.fit(
-            [(train_dataloader, train_loss),],
+            [
+                (train_dataloader, train_loss),
+            ],
             epochs=1,
             steps_per_epoch=gpl_steps,
             warmup_steps=1000,
@@ -185,66 +259,169 @@ def train(
             checkpoint_save_total_limit=10000,
             output_path=output_dir,
             checkpoint_path=output_dir,
-            use_amp=use_amp
+            use_amp=use_amp,
         )
     else:
-        logger.info('Trained GPL model found. Now skip training')
-
+        logger.info("Trained GPL model found. Now skip training")
 
     ### Evaluate the model if required ###
     if do_evaluation:
-        logger.info('Doing evaluation for GPL')
+        logger.info("Doing evaluation for GPL")
         evaluate(
-            evaluation_data, 
-            evaluation_output, 
-            ckpt_dir, 
+            evaluation_data,
+            evaluation_output,
+            ckpt_dir,
             max_seq_length,
             score_function=gpl_score_function,
             pooling=pooling,
-            split=eval_split
+            split=eval_split,
         )
-    
 
     ### Train and evaluate QGen
     if mnrl_output_dir is not None:
-        assert mnrl_evaluation_output is not None, "Evaluation path for MNRL should not be None, either"
+        assert (
+            mnrl_evaluation_output is not None
+        ), "Evaluation path for MNRL should not be None, either"
         ckpt_dir = mnrl_output_dir
-        if not os.path.exists(ckpt_dir) or (os.path.exists(ckpt_dir) and not os.listdir(ckpt_dir)):
-            logger.info('Now training MNRL on generated data')
-            mnrl(path_to_generated_data, base_ckpt, mnrl_output_dir, max_seq_length, use_amp, qgen_prefix)
+        if not os.path.exists(ckpt_dir) or (
+            os.path.exists(ckpt_dir) and not os.listdir(ckpt_dir)
+        ):
+            logger.info("Now training MNRL on generated data")
+            mnrl(
+                path_to_generated_data,
+                base_ckpt,
+                mnrl_output_dir,
+                max_seq_length,
+                use_amp,
+                qgen_prefix,
+            )
         else:
-            logger.info('Trained MNRL model found. Now skip training')
+            logger.info("Trained MNRL model found. Now skip training")
 
-        logger.info('Doing evaluation for QGen (MNRL)')
-        evaluate(evaluation_data, mnrl_evaluation_output, ckpt_dir, max_seq_length, score_function='cos_sim', pooling=pooling, split=eval_split)
+        logger.info("Doing evaluation for QGen (MNRL)")
+        evaluate(
+            evaluation_data,
+            mnrl_evaluation_output,
+            ckpt_dir,
+            max_seq_length,
+            score_function="cos_sim",
+            pooling=pooling,
+            split=eval_split,
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--path_to_generated_data', required=True, help='Path for/to the generated data. GPL will first check this path for a `corpus.jsonl` file for the (sole) data input of the whole pipeline. If an empty folder is indicated, query generation and hard-negative mining will be run automatically; one can also use a BeIR-QGen format data folder to start and skip the query generation.')
-    parser.add_argument('--output_dir', required=True, help='Output path for the GPL model.')
-    parser.add_argument('--do_evaluation', action='store_true', default=False, help='Wether to do the evaluation (after training)')
-    parser.add_argument('--evaluation_data', type=str, help='Path to the BeIR-format dataset. This is the next folder GPL goes to for the target corpus if there is no `corpus.jsonl` under `path_to_generated_data`')
-    parser.add_argument('--evaluation_output', default='output', help='Path for the evaluation output.')
-    parser.add_argument('--qgen_prefix', default='qgen', help='This prefix will appear as part of the (folder/file) names for query-generation results: For example, we will have "qgen-qrels/" and "qgen-queries.jsonl" by default.')
-    parser.add_argument('--base_ckpt', default='distilbert-base-uncased', help='Initialization checkpoint in HF or SBERT format. Meaning-pooling will be used.')
-    parser.add_argument('--generator', default='BeIR/query-gen-msmarco-t5-base-v1')
-    parser.add_argument('--cross_encoder', default='cross-encoder/ms-marco-MiniLM-L-6-v2')
-    parser.add_argument('--batch_size_gpl', type=int, default=32)
-    parser.add_argument('--batch_size_generation', type=int, default=10, help='Batch size in the query generation step.')
-    parser.add_argument('--pooling', type=str, default=None, choices=['cls', 'mean', 'max'], help="Specifying pooling method for dense retriever if in Huggingface-format. By default (None), it uses mean pooling. If in SBERT-format, there would be the indicated pooling method in its configure file and thus this argument will be ignored. ")
-    parser.add_argument('--max_seq_length', type=int, default=350)
-    parser.add_argument('--new_size', type=int, default=None, help='Resize the corpus to `new_size` (|corpus|) if needed. When set to None (by default), the |corpus| will be the full size. When set to -1, the |corpus| will be set automatically: If QPP * |corpus| <= 250K, |corpus| will be the full size; else QPP will be set 3 and |corpus| will be set to 250K / 3')
-    parser.add_argument('--queries_per_passage', type=int, default=-1, help='Number of Queries Per Passage (QPP) in the query generation step. When set to -1 (by default), the QPP will be chosen automatically: If QPP * |corpus| <= 250K, then QPP will be set to 250K / |corpus|; else QPP will be set 3 and |corpus| will be set to 250K / 3')
-    parser.add_argument('--gpl_steps', type=int, default=140000, help='Training steps for GPL.')
-    parser.add_argument('--use_amp', action='store_true', default=False, help='Whether to use half precision')
-    parser.add_argument('--retrievers', nargs='+', default=['msmarco-distilbert-base-v3', 'msmarco-MiniLM-L-6-v3'], help='Indicate retriever names for mining negatives. They could be one or many BM25 ("bm25") or dense retrievers (in SBERT format).')
-    parser.add_argument('--retriever_score_functions', nargs='+', default=['cos_sim', 'cos_sim'], choices=['dot', 'cos_sim', 'none'], help='Score functions of the corresponding retrievers for negative mining. Please set it to "none" for BM25.')
-    parser.add_argument('--gpl_score_function', choices=['dot', 'cos_sim'], default='dot')
-    parser.add_argument('--rescale_range', nargs='+', type=float, default=None, help='Rescale the pseudo labels (i.e. score margins) to a certain range. For example, we can set this to "-2 2", which represents the margin range based on cosine-similarity. By default, it will not do rescaling.')
-    parser.add_argument('--negatives_per_query', type=int, default=50, help="Mine how many negatives per query per retriever")
-    parser.add_argument('--mnrl_output_dir', default=None)
-    parser.add_argument('--mnrl_evaluation_output', default=None)
-    parser.add_argument('--eval_split', type=str, default='test', choices=['train', 'test', 'dev'], help='Which split to evaluate on') 
-    parser.add_argument('--use_train_qrels', action='store_true', default=False)
+    parser.add_argument(
+        "--path_to_generated_data",
+        required=True,
+        help="Path for/to the generated data. GPL will first check this path for a `corpus.jsonl` file for the (sole) data input of the whole pipeline. If an empty folder is indicated, query generation and hard-negative mining will be run automatically; one can also use a BeIR-QGen format data folder to start and skip the query generation.",
+    )
+    parser.add_argument(
+        "--output_dir", required=True, help="Output path for the GPL model."
+    )
+    parser.add_argument(
+        "--do_evaluation",
+        action="store_true",
+        default=False,
+        help="Wether to do the evaluation (after training)",
+    )
+    parser.add_argument(
+        "--evaluation_data",
+        type=str,
+        help="Path to the BeIR-format dataset. This is the next folder GPL goes to for the target corpus if there is no `corpus.jsonl` under `path_to_generated_data`",
+    )
+    parser.add_argument(
+        "--evaluation_output", default="output", help="Path for the evaluation output."
+    )
+    parser.add_argument(
+        "--qgen_prefix",
+        default="qgen",
+        help='This prefix will appear as part of the (folder/file) names for query-generation results: For example, we will have "qgen-qrels/" and "qgen-queries.jsonl" by default.',
+    )
+    parser.add_argument(
+        "--base_ckpt",
+        default="distilbert-base-uncased",
+        help="Initialization checkpoint in HF or SBERT format. Meaning-pooling will be used.",
+    )
+    parser.add_argument("--generator", default="BeIR/query-gen-msmarco-t5-base-v1")
+    parser.add_argument(
+        "--cross_encoder", default="cross-encoder/ms-marco-MiniLM-L-6-v2"
+    )
+    parser.add_argument("--batch_size_gpl", type=int, default=32)
+    parser.add_argument(
+        "--batch_size_generation",
+        type=int,
+        default=10,
+        help="Batch size in the query generation step.",
+    )
+    parser.add_argument(
+        "--pooling",
+        type=str,
+        default=None,
+        choices=["cls", "mean", "max"],
+        help="Specifying pooling method for dense retriever if in Huggingface-format. By default (None), it uses mean pooling. If in SBERT-format, there would be the indicated pooling method in its configure file and thus this argument will be ignored. ",
+    )
+    parser.add_argument("--max_seq_length", type=int, default=350)
+    parser.add_argument(
+        "--new_size",
+        type=int,
+        default=None,
+        help="Resize the corpus to `new_size` (|corpus|) if needed. When set to None (by default), the |corpus| will be the full size. When set to -1, the |corpus| will be set automatically: If QPP * |corpus| <= 250K, |corpus| will be the full size; else QPP will be set 3 and |corpus| will be set to 250K / 3",
+    )
+    parser.add_argument(
+        "--queries_per_passage",
+        type=int,
+        default=-1,
+        help="Number of Queries Per Passage (QPP) in the query generation step. When set to -1 (by default), the QPP will be chosen automatically: If QPP * |corpus| <= 250K, then QPP will be set to 250K / |corpus|; else QPP will be set 3 and |corpus| will be set to 250K / 3",
+    )
+    parser.add_argument(
+        "--gpl_steps", type=int, default=140000, help="Training steps for GPL."
+    )
+    parser.add_argument(
+        "--use_amp",
+        action="store_true",
+        default=False,
+        help="Whether to use half precision",
+    )
+    parser.add_argument(
+        "--retrievers",
+        nargs="+",
+        default=["msmarco-distilbert-base-v3", "msmarco-MiniLM-L-6-v3"],
+        help='Indicate retriever names for mining negatives. They could be one or many BM25 ("bm25") or dense retrievers (in SBERT format).',
+    )
+    parser.add_argument(
+        "--retriever_score_functions",
+        nargs="+",
+        default=["cos_sim", "cos_sim"],
+        choices=["dot", "cos_sim", "none"],
+        help='Score functions of the corresponding retrievers for negative mining. Please set it to "none" for BM25.',
+    )
+    parser.add_argument(
+        "--gpl_score_function", choices=["dot", "cos_sim"], default="dot"
+    )
+    parser.add_argument(
+        "--rescale_range",
+        nargs="+",
+        type=float,
+        default=None,
+        help='Rescale the pseudo labels (i.e. score margins) to a certain range. For example, we can set this to "-2 2", which represents the margin range based on cosine-similarity. By default, it will not do rescaling.',
+    )
+    parser.add_argument(
+        "--negatives_per_query",
+        type=int,
+        default=50,
+        help="Mine how many negatives per query per retriever",
+    )
+    parser.add_argument("--mnrl_output_dir", default=None)
+    parser.add_argument("--mnrl_evaluation_output", default=None)
+    parser.add_argument(
+        "--eval_split",
+        type=str,
+        default="test",
+        choices=["train", "test", "dev"],
+        help="Which split to evaluate on",
+    )
+    parser.add_argument("--use_train_qrels", action="store_true", default=False)
     args = parser.parse_args()
     train(**vars(args))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="gpl",
-    version="0.1.1",
+    version="0.1.2",
     author="Kexin Wang",
     author_email="kexin.wang.2049@gmail.com",
     description="GPL is an unsupervised domain adaptation method for training dense retrievers. It is based on query generation and pseudo labeling with powerful cross-encoders. To train a domain-adapted model, it needs only the unlabeled target corpus and can achieve significant improvement over zero-shot models.",
@@ -23,8 +23,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=[
-        'beir',
-        'easy-elasticsearch>=0.0.7'
-    ],
+    install_requires=["beir", "easy-elasticsearch>=0.0.8", "protobuf"],
 )


### PR DESCRIPTION
- `README.md`: Hint of installing PyTorch correctly wrt. the CUDA version.
- `gpl/toolkit/beir.py`: Black
- `gpl/toolkit/dataset.py`: Black 
- `gpl/toolkit/evaluation.py`: Black
- `gpl/toolkit/log.py`: Black
- `gpl/toolkit/loss.py`: Black
- `gpl/toolkit/mine.py`: Black
- `gpl/toolkit/mnrl.py`: Black
- `gpl/toolkit/pl.py`: Black
- `gpl/toolkit/qgen.py`: Black
- `gpl/toolkit/reformat.py`: Black
- `gpl/toolkit/rescale.py`: Black
- `gpl/toolkit/resize.py`: Black
- `gpl/toolkit/sbert.py`: Black
- `gpl/train.py`: Black
- `setup.py`: Added `protobuf`, required by T5 and seems to be ignored by simply installing transformer; specified ees>=0.0.8 (where the es version is kept the same with that required by `beir`)