### PR TITLE
OOM error in loadable checking

### DIFF
--- a/gpl/toolkit/sbert.py
+++ b/gpl/toolkit/sbert.py
@@ -11,8 +11,11 @@ def directly_loadable_by_sbert(model: SentenceTransformer):
             "This is an input text",
         ]
         model.encode(texts)
-    except RuntimeError:
-        loadable_by_sbert = False
+    except RuntimeError as e:
+        if "CUDA out of memory" in str(e):
+            raise e
+        else:
+            loadable_by_sbert = False
     return loadable_by_sbert
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=["beir", "easy-elasticsearch>=0.0.9", "protobuf"],
+    install_requires=["beir", "easy-elasticsearch>=0.0.9", "protobuf", "pytest"],
 )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+import tempfile
+from transformers.models.bert.modeling_bert import BertModel
+from transformers.models.bert.tokenization_bert import BertTokenizer
+from transformers.models.bert.configuration_bert import BertConfig
+from sentence_transformers import SentenceTransformer
+import shutil
+
+
+@pytest.fixture(name="sbert", scope="session")
+def sbert_fixture() -> SentenceTransformer:
+    try:
+        local_dir = tempfile.mkdtemp()
+
+        vocab = [
+            "[PAD]",
+            "[UNK]",
+            "[CLS]",
+            "[SEP]",
+            "[MASK]",
+            "the",
+            "of",
+            "and",
+            "in",
+            "to",
+            "was",
+            "he",
+        ]
+        vocab_file = os.path.join(local_dir, "vocab.txt")
+        with open(vocab_file, "w") as f:
+            f.writelines(vocab)
+
+        config = BertConfig(
+            vocab_size=len(vocab),
+            hidden_size=2,
+            num_attention_heads=1,
+            num_hidden_layers=2,
+            intermediate_size=2,
+            max_position_embeddings=10,
+        )
+
+        bert = BertModel(config)
+        tokenizer = BertTokenizer(vocab_file)
+
+        bert.save_pretrained(local_dir)
+        tokenizer.save_pretrained(local_dir)
+
+        yield SentenceTransformer(local_dir)
+    finally:
+        shutil.rmtree(local_dir)
+        print("Cleared temporary SBERT/BERT model")

--- a/tests/unit/test_sbert.py
+++ b/tests/unit/test_sbert.py
@@ -1,0 +1,13 @@
+from sentence_transformers import SentenceTransformer
+from unittest import mock
+from gpl.toolkit.sbert import directly_loadable_by_sbert
+import pytest
+
+
+def test_loadable_by_sbert_oom(sbert: SentenceTransformer):
+    with mock.patch.object(SentenceTransformer, "encode") as sbert_encode:
+        sbert_encode.side_effect = RuntimeError(
+            "CUDA out of memory. Tried to allocate ..."
+        )
+        with pytest.raises(RuntimeError):
+            directly_loadable_by_sbert(sbert)


### PR DESCRIPTION
The current version could not identify OOM error in `loadable_by_sbert_oom`, since OOM is also a runtime error and this loadable checking views all runtime errors as not loadable

- `modified:   gpl/toolkit/sbert.py`: Raise OOM error (runtime error)
-  `modified:   setup.py`: Added pytest
- `new file:   tests/unit/conftest.py`: SBERT fixture
- `new file:   tests/unit/test_sbert.py`: Test OOM error case