### PR TITLE
[KTLO-5] batch size larger than data size

### DIFF
--- a/gpl/toolkit/pl.py
+++ b/gpl/toolkit/pl.py
@@ -66,6 +66,15 @@ class PseudoLabeler(object):
         return decoded
 
     def run(self):
+        number_of_data_points = len(self.hard_negative_dataloader.dataset)
+        batch_size = self.hard_negative_dataloader.batch_size
+
+        if number_of_data_points < batch_size:
+            raise ValueError(
+                "Batch size larger than number of data points "
+                f"(batch size: {batch_size}, number of data points: {number_of_data_points})"
+            )
+
         # header: 'query_id', 'positive_id', 'negative_id', 'pseudo_label_margin'
         data = []
 

--- a/gpl/toolkit/pl.py
+++ b/gpl/toolkit/pl.py
@@ -71,8 +71,9 @@ class PseudoLabeler(object):
 
         if number_of_data_points < batch_size:
             raise ValueError(
-                "Batch size larger than number of data points "
-                f"(batch size: {batch_size}, number of data points: {number_of_data_points})"
+                "Batch size larger than number of data points / generated queries "
+                f"(batch size: {batch_size}, "
+                f"number of data points / generated queries: {number_of_data_points})"
             )
 
         # header: 'query_id', 'positive_id', 'negative_id', 'pseudo_label_margin'

--- a/tests/unit/test_pl.py
+++ b/tests/unit/test_pl.py
@@ -1,0 +1,29 @@
+from gpl.toolkit.pl import PseudoLabeler
+from unittest import mock
+from torch.utils.data import DataLoader
+import pytest
+
+
+def test_too_large_batch_size():
+    # Given:
+    mock_pl = mock.patch.object(PseudoLabeler, "__init__", return_value=None)
+    hard_negative_dataloader = DataLoader(["data"], batch_size=2)
+    hints = [
+        "Batch size larger than number of data points",
+        "batch size:",
+        "number of data points:",
+    ]
+
+    # When and then:
+    with mock_pl:
+        pl = PseudoLabeler(None, None, None, None, None, None, None)
+        pl.hard_negative_dataloader = hard_negative_dataloader
+        pl.total_steps = 10
+        with pytest.raises(ValueError):
+            pl.run()
+
+        try:
+            pl.run()
+        except ValueError as e:
+            for hint in hints:
+                assert hint in str(e)

--- a/tests/unit/test_pl.py
+++ b/tests/unit/test_pl.py
@@ -9,9 +9,9 @@ def test_too_large_batch_size():
     mock_pl = mock.patch.object(PseudoLabeler, "__init__", return_value=None)
     hard_negative_dataloader = DataLoader(["data"], batch_size=2)
     hints = [
-        "Batch size larger than number of data points",
+        "Batch size larger than number of data points / generated queries ",
         "batch size:",
-        "number of data points:",
+        "number of data points / generated queries:",
     ]
 
     # When and then:


### PR DESCRIPTION
The previous code did not check whether the batch size is larger than the number of data points (or number of generated queries) in `PseudoLabeler.run`

- `pl/toolkit/pl.py`: Added check at the beginning of `run` about batch size vs data size
- `tests/unit/test_pl.py`: Added test