### PR TITLE
[KTLO-6] Hints for missing evaluation data

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,8 +8,8 @@ from sentence_transformers import SentenceTransformer
 import shutil
 
 
-@pytest.fixture(name="sbert", scope="session")
-def sbert_fixture() -> SentenceTransformer:
+@pytest.fixture(name="sbert_path", scope="session")
+def sbert_path_fixture() -> str:
     try:
         local_dir = tempfile.mkdtemp()
 
@@ -29,7 +29,7 @@ def sbert_fixture() -> SentenceTransformer:
         ]
         vocab_file = os.path.join(local_dir, "vocab.txt")
         with open(vocab_file, "w") as f:
-            f.writelines(vocab)
+            f.write("\n".join(vocab))
 
         config = BertConfig(
             vocab_size=len(vocab),
@@ -46,7 +46,12 @@ def sbert_fixture() -> SentenceTransformer:
         bert.save_pretrained(local_dir)
         tokenizer.save_pretrained(local_dir)
 
-        yield SentenceTransformer(local_dir)
+        yield local_dir
     finally:
         shutil.rmtree(local_dir)
         print("Cleared temporary SBERT/BERT model")
+
+
+@pytest.fixture(name="sbert", scope="session")
+def sbert_fixture(sbert_path: str) -> SentenceTransformer:
+    yield SentenceTransformer(sbert_path)

--- a/tests/unit/test_eval.py
+++ b/tests/unit/test_eval.py
@@ -1,0 +1,29 @@
+from gpl.toolkit.evaluation import evaluate, GenericDataLoader
+from unittest import mock
+import pytest
+
+
+def test_missing_evaluation_data(sbert_path: str):
+    # Given:
+    mock_load = mock.patch.object(
+        GenericDataLoader,
+        "load",
+        side_effect=ValueError("File xxx not present! Please provide accurate file."),
+    )
+    hints = [
+        "Missing evaluation data files",
+        "Please put them under",
+        "or set `do_evaluation`=False",
+    ]
+
+    # When and then:
+    with mock_load:
+        try:
+            evaluate(
+                "dummy",
+                None,
+                sbert_path,
+            )
+        except ValueError as e:
+            for hint in hints:
+                assert hint in str(e)


### PR DESCRIPTION
The previous code does not give enough hint about missing evaluation data

- `gpl/toolkit/evaluation.py`: Added checking for missing evaluation data
- `tests/unit/conftest.py`: Separated sbert and sbert_path fixtures
- `tests/unit/test_eval.py`: Added test