### PR TITLE
use pytrec_eval-terrier fork of pytrec_eval

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -95,7 +95,7 @@ dependencies:
     - pyarrow==6.0.1
     - pyparsing==3.0.9
     - python-dateutil==2.8.2
-    - pytrec_eval-terrier==0.5.5
+    - pytrec-eval-terrier==0.5.5
     - pytz==2022.2.1
     - pyyaml==6.0
     - regex==2022.9.13

--- a/environment.yml
+++ b/environment.yml
@@ -95,7 +95,7 @@ dependencies:
     - pyarrow==6.0.1
     - pyparsing==3.0.9
     - python-dateutil==2.8.2
-    - pytrec-eval==0.5
+    - pytrec_eval-terrier==0.5.5
     - pytz==2022.2.1
     - pyyaml==6.0
     - regex==2022.9.13


### PR DESCRIPTION
Consider using [this fork](https://github.com/terrierteam/pytrec_eval/) of pytrec_eval, which is maintained for newer Python distributions and is Windows compatible.